### PR TITLE
restructuring for shared use PyPy / CPython

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,19 @@
 releases/
 root-*/
-src/
+src/CMakeLists.txt
+src/LICENSE
+src/Makefile
+src/build
+src/cmake
+src/config
+src/core
+src/cppyy
+src/etc
+src/interpreter
+src/io
+src/main
+src/math
+
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 # Include the license file
 include LICENSE.txt
 
-# Include the data files
+# Force-include the full source (a custom build is used)
 recursive-include src *

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,8 @@
-PyPy cling-support
-==================
+cppyy backend contaning Cling/LLVM
+==================================
 
 ----
 
 Find the documentation here:
-  http://doc.pypy.org/en/latest/cppyy.html
+   http://cppyy.readthedocs.io/
+

--- a/create_src_directory.py
+++ b/create_src_directory.py
@@ -10,19 +10,19 @@ DEBUG_TESTBUILD = False
 TARBALL_CACHE_DIR = 'releases'
 
 ROOT_KEEP = ['build', 'cmake', 'config', 'core', 'etc', 'interpreter',
-             'io', 'LICENSE', 'net', 'Makefile', 'CMakeLists.txt', 'math',
+             'io', 'LICENSE', 'Makefile', 'CMakeLists.txt', 'math',
              'main'] # main only needed in more recent root b/c of rootcling
 ROOT_CORE_KEEP = ['CMakeLists.txt', 'base', 'clib', 'clingutils', 'cont',
                   'dictgen', 'foundation', 'lzma', 'macosx', 'meta',
                   'metacling', 'metautils', 'rootcling_stage1', 'textinput',
                   'thread', 'unix', 'utils', 'winnt', 'zip']
 ROOT_IO_KEEP = ['CMakeLists.txt', 'io', 'rootpcm']
-ROOT_NET_KEEP = ['CMakeLists.txt', 'net']
 ROOT_MATH_KEEP = ['CMakeLists.txt', 'mathcore']
 ROOT_ETC_KEEP = ['Makefile.arch', 'class.rules', 'cmake', 'dictpch',
                  'gdb-backtrace.sh', 'gitinfo.txt', 'helgrind-root.supp',
-                 'hostcert.conf', 'system.plugins-ios',
+                 'hostcert.conf', 'plugins', 'system.plugins-ios',
                  'valgrind-root-python.supp', 'valgrind-root.supp', 'vmc']
+ROOT_PLUGINS_KEEP = ['TVirtualStreamerInfo']
 
 ROOT_EXPLICIT_REMOVE = ['core/base/v7', 'math/mathcore/v7', 'io/io/v7']
 
@@ -33,7 +33,7 @@ ERR_RELEASE_NOT_FOUND = 2
 def get_root_version():
     import pkg_resources
     try:
-        version = pkg_resources.get_distribution('PyPy_cppyy_backend').version
+        version = pkg_resources.get_distribution('cppyy_backend').version
     except pkg_resources.DistributionNotFound:
         print('ERROR: cannot determine the version. Please run setup.py egg_info first')
         sys.exit(1)
@@ -87,7 +87,6 @@ def clean_directory(directory, keeplist, trim_cmake=True):
         print('reusing existing %s/CMakeLists.txt' % (directory,))
  
 
-
 if not os.path.exists(TARBALL_CACHE_DIR):
     os.mkdir(TARBALL_CACHE_DIR)
 
@@ -122,9 +121,9 @@ os.chdir(pkgdir)
 clean_directory(os.path.curdir, ROOT_KEEP)
 clean_directory('core',         ROOT_CORE_KEEP)
 clean_directory('etc',          ROOT_ETC_KEEP, trim_cmake=False)
+clean_directory('etc/plugins',  ROOT_PLUGINS_KEEP, trim_cmake=False)
 clean_directory('io',           ROOT_IO_KEEP)
 clean_directory('math',         ROOT_MATH_KEEP)
-clean_directory('net',          ROOT_NET_KEEP)
 
 
 # trim main (only need rootcling)
@@ -209,12 +208,14 @@ for line in open(inp):
 new_cml.close()
 os.rename(outp, inp)
 
+
 # some more explicit removes:
 for dir_to_remove in ROOT_EXPLICIT_REMOVE:
     try:
         shutil.rmtree(dir_to_remove)
     except OSError:
         pass
+
 
 # special fixes
 inp = 'core/base/src/TVirtualPad.cxx'
@@ -228,6 +229,36 @@ typedef struct _x3d_sizeof_ {
    int  numSegs;
    int  numPolys;
 } Size3D;
+"""
+    new_cml.write(line)
+new_cml.close()
+os.rename(outp, inp)
+
+inp = 'core/unix/src/TUnixSystem.cxx'
+outp = inp+'.new'
+new_cml = open(outp, 'w')
+for line in open(inp):
+    if '#include "TSocket.h"' == line[0:20]:
+        line = """//#include "TSocket.h"
+enum ESockOptions {
+   kSendBuffer,        // size of send buffer
+   kRecvBuffer,        // size of receive buffer
+   kOobInline,         // OOB message inline
+   kKeepAlive,         // keep socket alive
+   kReuseAddr,         // allow reuse of local portion of address 5-tuple
+   kNoDelay,           // send without delay
+   kNoBlock,           // non-blocking I/O
+   kProcessGroup,      // socket process group (used for SIGURG and SIGIO)
+   kAtMark,            // are we at out-of-band mark (read only)
+   kBytesToRead        // get number of bytes to read, FIONREAD (read only)
+};
+
+enum ESendRecvOptions {
+   kDefault,           // default option (= 0)
+   kOob,               // send or receive out-of-band data
+   kPeek,              // peek at incoming message (receive only)
+   kDontBlock          // send/recv as much data as possible without blocking
+};
 """
     new_cml.write(line)
 new_cml.close()
@@ -264,17 +295,21 @@ if DEBUG_TESTBUILD:
 #
 countdown = 0
 
-print('creating src ... ROOT part')
-if not os.path.exists('src'):
-    os.mkdir('src')
-os.chdir('src'); countdown += 1
-if not os.path.exists('backend'):
-    src = os.path.join(os.path.pardir, pkgdir)
-    print('now copying', src)
-    shutil.copytree(src, 'backend')
+print('adding src ... ROOT part')
+for entry in os.listdir(pkgdir):
+    fullp = os.path.join(pkgdir, entry)
+    if entry[0] == '.':
+        continue
+    dest = os.path.join('src', entry)
+    if os.path.isdir(fullp):
+        if not os.path.exists(dest):
+            shutil.copytree(fullp, dest)
+    else:
+        if not os.path.exists(dest):
+            shutil.copy2(fullp, dest)
 
 print('creating src ... cppyy part')
-os.chdir('backend'); countdown += 1
+os.chdir('src'); countdown += 1
 if not os.path.exists('cppyy'):
     os.mkdir('cppyy')
     os.chdir('cppyy'); countdown += 1
@@ -298,8 +333,8 @@ add_dependencies(cppyy_backend CLING)
 
     os.mkdir('src')
     os.chdir('src'); countdown += 1
-    print('pulling cppyy/clingcwrapper.cxx from pypy')
-    base = 'https://bitbucket.org/pypy/pypy/raw/default/pypy/module/cppyy/'
+    print('pulling _cppyy/clingcwrapper.cxx from pypy')
+    base = 'https://bitbucket.org/pypy/pypy/raw/default/pypy/module/_cppyy/'
     for cppyy_file in ['src/callcontext.h', 'include/capi.h', 'src/clingcwrapper.cxx',
                        'include/clingcwrapper.h', 'include/cpp_cppyy.h', 'include/cppyy.h']:
         resp = urllib2.urlopen(base+cppyy_file)
@@ -401,8 +436,8 @@ add_dependencies(cppyy_backend CLING)
 for i in range(countdown):
     os.chdir(os.path.pardir)
 
-# add cppyy module to cmake
-os.chdir('src/backend')
+# add cppyy cling wrapper code to cmake
+os.chdir('src')
 inp = 'CMakeLists.txt'
 print('adding cppyy to cmake')
 outp = inp+'.new'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [bdist_wheel]
-universal=0
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 from distutils import log
 from distutils.command.build import build as _build
 from setuptools.command.install import install as _install
-from distutils.sysconfig import get_python_lib
+from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 from distutils.errors import DistutilsSetupError
 from codecs import open
 
@@ -24,23 +24,18 @@ def get_srcdir():
     global srcdir
     if srcdir is None:
         topdir = os.getcwd()
-        srcdir = os.path.join(topdir, 'src', 'backend')
+        srcdir = os.path.join(topdir, 'src')
     return srcdir
 
-class my_cmake_build(_build):
-    def __init__(self, dist, *args, **kwargs):
-        _build.__init__(self, dist, *args, **kwargs)
-        # TODO: can't seem to find a better way of getting hold of
-        # the install_lib parameter during the build phase ...
-        prefix = ''
-        try:
-            prefix = dist.get_command_obj('install').install_lib
-        except AttributeError:
-            pass
-        if not prefix:
-            prefix = get_python_lib(1, 0)
-        self.prefix = os.path.join(prefix, 'cppyy_backend')
+prefix = None
+def get_prefix():
+    global prefix
+    if prefix is None:
+        prefix = os.path.join(get_builddir(), 'install', 'cppyy_backend')
+    return prefix
 
+
+class my_cmake_build(_build):
     def run(self):
         # base run
         _build.run(self)
@@ -48,16 +43,19 @@ class my_cmake_build(_build):
         # custom run
         log.info('Now building libcppyy_backend.so and dependencies')
         builddir = get_builddir()
-        srcdir = get_srcdir()
+        prefix   = get_prefix()
+        srcdir   = get_srcdir()
         if not os.path.exists(builddir):
             log.info('Creating build directory %s ...' % builddir)
             os.makedirs(builddir)
 
+        olddir = os.getcwd()
         os.chdir(builddir)
         log.info('Running cmake for cppyy_backend')
         if subprocess.call([
                 'cmake', srcdir, '-Dminimal=ON -Dasimage=OFF',
-                '-DCMAKE_INSTALL_PREFIX='+self.prefix]) != 0:
+                '-DCMAKE_INSTALL_PREFIX='+prefix]) != 0:
+            os.chdir(olddir)
             raise DistutilsSetupError('Failed to configure cppyy_backend')
 
         nprocs = os.getenv("MAKE_NPROCS")
@@ -74,35 +72,61 @@ class my_cmake_build(_build):
         if subprocess.call(['make', nprocs]) != 0:
             raise DistutilsSetupError('Failed to build cppyy_backend')
 
+        os.chdir(olddir)
         log.info('build finished')
 
-class my_libs_install(_install):
+class my_install(_install):
+    def _get_install_path(self):
+        # depending on goal, copy over pre-installed tree
+        if hasattr(self, 'bdist_dir') and self.bdist_dir:
+            install_path = self.bdist_dir
+        else:
+            install_path = self.install_lib
+        return install_path
+
     def run(self):
         # base install
         _install.run(self)
 
-        # custom install
+        # custom install of backend
         log.info('Now installing libcppyy_backend.so and dependencies')
         builddir = get_builddir()
         if not os.path.exists(builddir):
             raise DistutilsSetupError('Failed to find build dir!')
+        olddir = os.getcwd()
         os.chdir(builddir)
 
-        prefix = self.install_lib
-        log.info('Now installing in %s ...', prefix)
+        prefix = get_prefix()
+        log.info('Now creating installation under %s ...', prefix)
         if subprocess.call(['make', 'install']) != 0:
+            os.chdir(olddir)
             raise DistutilsSetupError('Failed to install cppyy_backend')
+
+        os.chdir(olddir)
+        prefix_base = os.path.join(get_prefix(), os.path.pardir)
+        install_path = self._get_install_path()
+        log.info('Copying installation to: %s ...', install_path)
+        self.copy_tree(prefix_base, install_path)
 
         log.info('install finished')
 
     def get_outputs(self):
         outputs = _install.get_outputs(self)
-        outputs.append(os.path.join(self.install_lib, 'cppyy_backend'))
+        outputs.append(os.path.join(self._get_install_path(), 'cppyy_backend'))
         return outputs
 
+class my_bdist_wheel(_bdist_wheel):
+    def finalize_options(self):
+     # this is a universal, but platform-specific package; a combination
+     # that wheel does not recognize, thus simply fool it
+        from distutils.util import get_platform
+        self.plat_name = get_platform()
+        _bdist_wheel.finalize_options(self)
+
+
 setup(
-    name='PyPy-cppyy-backend',
-    description='Cling support for PyPy',
+    name='cppyy-backend',
+    description='cppyy backend containing Cling/LLVM',
     long_description=long_description,
     url='http://pypy.org',
 
@@ -128,20 +152,30 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: Implementation :: PyPy',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: C',
         'Programming Language :: C++',
 
         'Natural Language :: English'
     ],
 
-    keywords='interpreter development',
+    keywords='interpreter development, C++ bindings',
 
-    packages=find_packages('src', ['backend']),
     include_package_data=True,
+
+    package_dir={'': 'src'},
+    packages=find_packages('src', include=['cppyy_backend']),
 
     cmdclass = {
         'build': my_cmake_build,
-        'install': my_libs_install,
+        'install': my_install,
+        'bdist_wheel': my_bdist_wheel,
+    },
+
+    entry_points={
+        "console_scripts": [
+            "genreflex = cppyy_backend._genreflex:main",
+        ],
     },
 )
-

--- a/src/cppyy_backend/__init__.py
+++ b/src/cppyy_backend/__init__.py
@@ -1,0 +1,1 @@
+from . import _genreflex, loader

--- a/src/cppyy_backend/_genreflex.py
+++ b/src/cppyy_backend/_genreflex.py
@@ -1,0 +1,15 @@
+from __future__ import print_function
+import os, sys, subprocess
+
+MYHOME = os.path.dirname(__file__)
+
+def main():
+    if len(sys.argv) == 2 and \
+           (sys.argv[1] == '--cflags' or sys.argv[1] == '--cppflags'):
+        print('-I%s/include' % (MYHOME,))
+        return 0
+    os.environ['LD_LIBRARY_PATH'] = os.path.join(MYHOME, 'lib')
+    genreflex = os.path.join(MYHOME, 'bin', 'genreflex')
+    if not os.path.exists(genreflex):
+        raise RuntimeError("genreflex not installed in standard location")
+    return subprocess.call([genreflex] + sys.argv[1:])

--- a/src/cppyy_backend/loader.py
+++ b/src/cppyy_backend/loader.py
@@ -1,0 +1,17 @@
+""" cppyy_backend loader
+"""
+
+import os, ctypes
+
+def load_cpp_backend():
+    try:
+      # normal load, allowing for user overrides of LD_LIBRARY_PATH
+        c = ctypes.CDLL("libcppyy_backend.so", ctypes.RTLD_GLOBAL)
+    except OSError:
+      # failed ... load dependencies explicitly
+        libpath = os.path.join(os.path.dirname(__file__), 'lib')
+        for dep in ['libCore.so', 'libThread.so', 'libRIO.so', 'libCling.so']:
+           ctypes.CDLL(os.path.join(libpath, dep), ctypes.RTLD_GLOBAL)
+        c = ctypes.CDLL(os.path.join(libpath, 'libcppyy_backend.so'), ctypes.RTLD_GLOBAL)
+
+    return c


### PR DESCRIPTION
take out the net dependency
add back plugins/TVirtualStreamerInfo
repackage using loader (from python) and entry-points (for genreflex)
remove a level of indirection
make bdist_wheel universal
rename PyPy-cppyy-backend to cppyy-backend